### PR TITLE
add light-mode to start

### DIFF
--- a/packages/pepicons.com/src/pages/LandingPage.vue
+++ b/packages/pepicons.com/src/pages/LandingPage.vue
@@ -20,6 +20,9 @@ import { setUrlQuery, getQueryFromUrl } from '../helpers/urlHelpers'
 import { defaultsIconConfig } from '../types'
 import DialogWrapper from '../components/DialogWrapper.vue'
 import IconInfo from '../components/IconInfo.vue'
+
+document.body.classList.add('light-mode')
+
 const emit = defineEmits(['set-is-dark-mode', 'set-config'])
 
 const hash = getQueryFromUrl()


### PR DESCRIPTION
@mesqueeb 
We were just missing the initial light-mode class on start up